### PR TITLE
chore: add blueprints submodule and spec-driven development scaffolding

### DIFF
--- a/.claude/commands/analyze.md
+++ b/.claude/commands/analyze.md
@@ -1,0 +1,19 @@
+---
+description: Audit the active feature artifacts for cross-document consistency. Read-only.
+---
+Read the active `spec.md`, `plan.md`, `data-model.md`, `contracts/`, and
+`tasks.md`.
+
+Report, without editing anything:
+
+- Spec requirements with no corresponding plan section or task.
+- Plan or task content that implements behavior absent from the spec (scope
+  creep).
+- Contract rows with no task that produces their required evidence.
+- Contract rows marked `Covered` whose evidence is not actually present.
+- Shared logic named in the spec but not assigned an owning package or crate.
+- Any remaining `[NEEDS CLARIFY]` markers.
+
+Output a short findings list ordered by severity, then recommend the next
+command (`/clarify`, `/plan`, or `/tasks`) to close the gaps. Do not edit any
+file.

--- a/.claude/commands/clarify.md
+++ b/.claude/commands/clarify.md
@@ -1,0 +1,17 @@
+---
+description: Resolve ambiguities in the active spec by asking structured questions, then record the answers.
+---
+Read the active spec named in `.specify/feature.json`.
+
+1. Collect every `[NEEDS CLARIFY: ...]` marker plus any ambiguity you find in
+   acceptance criteria, data ownership, persistence, or shared-logic
+   boundaries.
+2. Ask the user the open questions as a short numbered list. Ask only what
+   changes the spec or plan -- skip cosmetic detail.
+3. Record each answer under a `## Clarifications` section in `spec.md`, then
+   remove the resolved `[NEEDS CLARIFY]` markers.
+4. If an answer changes behavior, update the affected user stories and
+   acceptance criteria in the same pass.
+
+Block `/plan` until no `[NEEDS CLARIFY]` markers remain. Do not edit production
+code.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,21 @@
+---
+description: Execute the active task list one user story or contract row at a time, evidence before ticking.
+---
+Read `.blueprints/domain/spec-driven-development.md`, the active `tasks.md`, and
+the relevant `contracts/` file before touching code.
+
+For each task, in dependency order:
+
+1. Work one user story or one contract row at a time.
+2. Read the contract row before editing the code it governs.
+3. Derive tests from the contract preconditions, postconditions, and
+   invariants. Write the test before the implementation.
+4. Implement the change.
+5. Run the evidence commands listed in the contract's `Required Evidence Before
+   Marking Complete` section.
+6. Only after the evidence passes: mark the contract row `Covered` and tick the
+   task checkbox.
+
+If implementation and spec disagree, stop -- update the spec via `/specify` or
+reject the change. Never tick a checkbox or contract row before its evidence
+runs green.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,18 @@
+---
+description: Produce the technical plan and supporting artifacts from the active spec.
+---
+Read the active spec and `.specify/memory/constitution.md`. Refuse to plan while
+`[NEEDS CLARIFY]` markers remain -- run `/clarify` first.
+
+From the spec, produce in the active feature directory:
+
+- `plan.md` -- implementation approach, gates, and the artifact checklist.
+- `research.md` -- decisions, rejected alternatives, references.
+- `data-model.md` -- entities, ownership, wire formats, migrations.
+- `contracts/*.md` -- one file per behavior surface, each with a contract matrix
+  (`Covered` / `Partial` / `Open`) and a `Required Evidence Before Marking
+  Complete` section.
+
+Name the owning package or crate for any logic shared across runtimes or
+languages. Check the plan against the constitution review gates. Do not edit
+production code or write tasks; that is `/tasks`.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,0 +1,22 @@
+---
+description: Create or refresh spec.md for a feature surface from a plain-language description.
+argument-hint: <feature description>
+---
+Read `.blueprints/domain/spec-driven-development.md` and
+`.specify/memory/constitution.md` first.
+
+Feature description: $ARGUMENTS
+
+1. Determine the active feature directory from `.specify/feature.json`. If the
+   description names a new surface, create `specs/NNN-feature-name/` (next free
+   `NNN`), copy `.blueprints/templates/spec-driven/feature/` into it, and point
+   `.specify/feature.json` at the new directory.
+2. Fill `spec.md` from the template: user stories with acceptance criteria,
+   functional and non-functional requirements, non-goals, and risks. Slice by
+   independently testable user stories.
+3. Write only behavior -- the "what" and "why". Do not choose a tech stack or
+   design internals here; that is `/plan`.
+4. Mark every unresolved ambiguity inline as `[NEEDS CLARIFY: ...]`. Do not
+   guess. Hand off to `/clarify` if any remain.
+
+Do not edit production code. The output is the spec only.

--- a/.claude/commands/tasks.md
+++ b/.claude/commands/tasks.md
@@ -1,0 +1,18 @@
+---
+description: Generate a dependency-ordered task list from the plan and contracts.
+---
+Read the active `spec.md`, `plan.md`, `data-model.md`, and `contracts/`.
+
+Write `tasks.md`:
+
+- Group tasks by user story, then by contract row.
+- Order by dependency. Mark tasks that can run in parallel -- no shared files,
+  no ordering constraint -- with `[P]`.
+- Give each task a stable id (`T001`, `T002`, ...) and name the exact files it
+  touches.
+- Pair each source task with the test or manual-QA task that produces its
+  contract evidence. Tests come before the implementation they cover.
+- End with a completion gate: run the project check/lint/test commands and
+  confirm every ticked checkbox has evidence.
+
+Do not edit production code.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".blueprints"]
+	path = .blueprints
+	url = https://github.com/virtualritz/blueprints

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-gpu-pixel-streaming"
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,85 @@
+# ɴsɪ Project Spec Constitution
+
+Adapted from `.blueprints/templates/spec-driven/constitution.md` for the ɴsɪ
+Rust workspace.
+
+## Core Principles
+
+### I. Source Of Truth First
+
+Feature behavior is governed by the active spec directory named in
+`.specify/feature.json`. Code, plans, TODOs, and agent claims must point back
+to contract files. If implementation and spec disagree, update the spec or
+reject the implementation before continuing.
+
+### II. Contract Evidence Is Required
+
+Every feature surface needs contracts with a matrix row for each important
+behavior. Each row is `Covered`, `Partial`, or `Open`. `Covered` requires
+source evidence plus executable test evidence or explicit manual QA evidence.
+Untested documentation is not evidence.
+
+### III. Small User Stories Beat Broad Architecture Docs
+
+Specs are sliced by independently testable user stories. A single session
+should target one user story or one contract gap. Architecture summaries may
+exist as context, but they are not a substitute for acceptance criteria,
+contracts, and tasks.
+
+### IV. Tests Follow Contracts
+
+Tests must be derived from contract preconditions, postconditions, invariants,
+and acceptance criteria. Deterministic logic needs automated tests
+(`cargo test`, never `--release` unless explicitly requested). Behavior that
+requires a running renderer (3Delight, `DELIGHT` env var) needs automated
+tests when practical and explicit manual QA steps when not.
+
+### V. Wire Formats And FFI Boundaries Are Product Behavior
+
+Attribute vocabularies, exported OS handles, shared-memory layouts, and any
+data crossing the FFI or a process boundary are contract surfaces. Any change
+must document compatibility, versioning, and failure mode. Silent fallback on
+required identifiers is forbidden -- fail loudly with typed errors.
+
+### VI. API Conformance Is A Contract
+
+Anything claiming ɴsɪ conformance must be expressible through the standard
+interface calls and node/attribute model. Renderer-specific behavior must be
+carried by attributes that a conforming implementation may ignore, and each
+such attribute must be named in a contract.
+
+### VII. Shared Logic Has One Owner
+
+Code needed by multiple crates in the workspace must have one named owner
+crate. Temporary duplication must be documented as `Partial` with a removal
+task.
+
+## Required Feature Artifacts
+
+Each feature surface must contain:
+
+- `spec.md`.
+- `plan.md`.
+- `research.md`.
+- `data-model.md`.
+- `contracts/*.md`.
+- `quickstart.md`.
+- `tasks.md`.
+- `checklists/requirements.md`.
+
+## Review Gates
+
+- `cargo build`, `cargo clippy`, and `cargo fmt --check` must pass before
+  claiming readiness unless a known unrelated failure is documented with exact
+  output.
+- Relevant crate tests must run for every changed surface.
+- Expected-image update commands (`RUST_TEST_UPDATE=1`) require explicit human
+  approval.
+- Plans and TODO checkboxes may be ticked only after their contract evidence
+  is present.
+
+## Governance
+
+This constitution applies unless a branch-specific constitution explicitly
+overrides it. Amendments require a commit changing this file, an explanation
+in the PR or handoff, and updates to affected specs/templates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,3 +248,21 @@ Adopt conventional commit prefixes (`feat:`, `fix:`, `chore:`). Keep messages co
 3. **Public API**: Minimize public surface area; use `pub(crate)` liberally.
 4. **Error Types**: Define domain-specific error types with `thiserror`.
 5. **Tests**: Co-locate unit tests; integration tests in `tests/`.
+
+<!-- SPEC-DRIVEN DEVELOPMENT START -->
+Spec-driven development is enabled for this repository.
+
+Before creating or changing a feature surface:
+
+- Read `.blueprints/domain/spec-driven-development.md`.
+- Read the active spec pointer in `.specify/feature.json`, or the project
+  equivalent named here.
+- Read the current feature plan before editing code.
+- Work one user story or one contract row at a time.
+- Mark contract rows `Covered` only after source evidence and test/manual QA
+  evidence are present.
+
+Project-specific specs live in `specs/`. Shared rules and templates live in
+`.blueprints/`.
+<!-- SPEC-DRIVEN DEVELOPMENT END -->
+

--- a/specs/001-gpu-pixel-streaming/checklists/requirements.md
+++ b/specs/001-gpu-pixel-streaming/checklists/requirements.md
@@ -11,8 +11,8 @@ unticked until its evidence exists.
   acquirable images, errors, counters).
 - [x] Non-goals are explicit (`spec.md` "Non-Goals").
 - [x] Risks are named (`spec.md` "Risks").
-- [ ] All `[NEEDS CLARIFY]` markers resolved (3 remain -- see `spec.md`;
-  blocked on `/clarify`).
+- [x] All `[NEEDS CLARIFY]` markers resolved (`spec.md` -- four RESOLVED
+  entries dated 2026-07-26; none remain).
 
 ## Contract Quality
 

--- a/specs/001-gpu-pixel-streaming/checklists/requirements.md
+++ b/specs/001-gpu-pixel-streaming/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Requirements Checklist: GPU-Resident Pixel Streaming
+
+Ticked items cite the document that satisfies them; everything else stays
+unticked until its evidence exists.
+
+## Spec Quality
+
+- [x] User stories are independently testable (`spec.md` -- each story has
+  its own contract rows and test commands).
+- [x] Acceptance criteria are observable (`spec.md` -- given/when/then over
+  acquirable images, errors, counters).
+- [x] Non-goals are explicit (`spec.md` "Non-Goals").
+- [x] Risks are named (`spec.md` "Risks").
+- [ ] All `[NEEDS CLARIFY]` markers resolved (3 remain -- see `spec.md`;
+  blocked on `/clarify`).
+
+## Contract Quality
+
+- [x] Every important behavior has a contract row
+  (`contracts/attribute-vocabulary.md`,
+  `contracts/publication-lifecycle.md`).
+- [x] Every row is `Covered`, `Partial`, or `Open` (all currently `Open`).
+- [ ] `Covered` rows cite source evidence (none yet -- no implementation).
+- [ ] `Covered` rows cite test or manual QA evidence (none yet).
+- [x] Required evidence is listed before work starts (both contract files).
+
+## Implementation Readiness
+
+- [ ] Tasks are small enough for single commits (`tasks.md` drafted; verify
+  during `/analyze` after clarifications).
+- [x] Persistence and migration behavior is documented (`data-model.md` --
+  versioned wire contract, no disk state).
+- [x] Shared logic ownership is named (`nsi-stream` crate,
+  `research.md` D5).

--- a/specs/001-gpu-pixel-streaming/contracts/attribute-vocabulary.md
+++ b/specs/001-gpu-pixel-streaming/contracts/attribute-vocabulary.md
@@ -1,0 +1,47 @@
+# Contract: Stream Attribute Vocabulary
+
+## Scope
+
+This contract covers parsing, validation, and negotiation of the
+`stream.*` attribute vocabulary on the `outputdriver` node (see
+`../data-model.md` for the table of record). It does not cover publication
+timing or image lifecycle (see `publication-lifecycle.md`).
+
+## Matrix
+
+| Behavior | Status | Source Evidence | Test/QA Evidence | Required Next Evidence |
+| --- | --- | --- | --- | --- |
+| Driver is addressed via `drivername "nsi-stream"`; all `stream.*` attributes reach it unmodified | Open | None | None | `cargo test -p nsi-stream vocabulary_forwarding` against the bridge or a mock driver. |
+| Missing `stream.version` or unsupported version fails open() with a typed error | Open | None | None | `cargo test -p nsi-stream vocabulary_version_reject`. |
+| Unknown `stream.*` attribute is ignored with a warning, not an error | Open | None | None | `cargo test -p nsi-stream vocabulary_unknown_attr_warns`. |
+| `stream.transport "auto"` negotiates gpu → shm → callback and reports the selected transport | Open | None | None | `cargo test -p nsi-stream transport_auto_negotiation` with forced-unviable fixtures. |
+| Explicit transport that is unviable fails open() with a typed error, no fallback | Open | None | None | `cargo test -p nsi-stream transport_explicit_no_fallback`. |
+| `stream.device.uuid` mismatch fails/falls back per transport rules | Open | None | None | `cargo test -p nsi-stream transport_device_mismatch`. |
+| Per-layer format from each connected `outputlayer` is honored (RGBA f16/f32 minimum) | Open | None | None | `cargo test -p nsi-stream layer_formats`; manual QA: multi-AOV example shows beauty + ID layer. |
+
+## Invariants
+
+- The contract is expressible through standard `NSICreate`/`NSISetAttribute`
+  /`NSIConnect` only; no new API calls (R1).
+- Client → renderer flow uses attributes only; the driver initiates every
+  reverse-direction message (D3, data-model "Direction").
+- Pointer-typed attributes appear only in the in-process callback transport
+  (R2).
+
+## Failure Modes
+
+- Unsupported version → typed `Error::UnsupportedVersion` at open; render
+  aborts the output chain for this driver only.
+- Unviable explicit transport → typed `Error::TransportUnavailable`; no
+  partial allocation (state machine: Configured → Failed).
+- Malformed handle/channel name → typed error naming the attribute.
+
+## Required Evidence Before Marking Complete
+
+- Source evidence must cite `crates/nsi-stream/src/` symbols implementing
+  each row (parser, negotiation, error types).
+- Executable evidence: the exact `cargo test -p nsi-stream <test_name>`
+  commands listed per row, run without `--release`.
+- Manual QA evidence (layer-format row): command line of the multi-AOV
+  example, environment (renderer + `DELIGHT` version if bridge), and the
+  observed result.

--- a/specs/001-gpu-pixel-streaming/contracts/publication-lifecycle.md
+++ b/specs/001-gpu-pixel-streaming/contracts/publication-lifecycle.md
@@ -1,0 +1,54 @@
+# Contract: Publication And Lifecycle
+
+## Scope
+
+This contract covers the publication ring, acquire/release, synchronization,
+resize, and teardown. It does not cover attribute parsing/negotiation (see
+`attribute-vocabulary.md`) or renderer-internal sampling/refinement policy.
+
+## Matrix
+
+| Behavior | Status | Source Evidence | Test/QA Evidence | Required Next Evidence |
+| --- | --- | --- | --- | --- |
+| `commit` mode: every publication carries one scene generation; no image mixes generations | Open | None | None | `cargo test -p nsi-stream publish_commit_atomic` -- two-generation scene, assert per-pixel generation tag uniformity via ID layer. |
+| `continuous` mode: acquired image never contains a torn bucket | Open | None | None | `cargo test -p nsi-stream publish_continuous_no_torn_bucket` with a checkered write-order fixture. |
+| Acquire is non-blocking and returns latest publication or none | Open | None | None | `cargo test -p nsi-stream acquire_nonblocking` (timed). |
+| Client waits on the Publication's timeline value before sampling; contents complete after wait | Open | None | None | `cargo test -p nsi-stream publication_semaphore_complete`. |
+| Renderer never stalls on a fully leased ring; publication drops latest-wins and increments drop counter | Open | None | None | `cargo test -p nsi-stream ring_exhaustion_drops` holding all tokens. |
+| Release returns the image to the ring; driver reuses only released images | Open | None | None | `cargo test -p nsi-stream release_reuse_ordering`. |
+| Resize: next publication has new extent; held pre-resize acquisitions stay valid until release | Open | None | None | `cargo test -p nsi-stream resize_drain_safety` under address sanitizer/miri where applicable. |
+| Close drains: no publications after close, final semaphore value signaled, GPU objects freed | Open | None | None | `cargo test -p nsi-stream close_drain`; leak check via validation layers. |
+| Client loss: driver detects channel close and honors `stream.onclientloss` | Open | None | None | `cargo test -p nsi-stream client_loss_behavior` (kill client end of socket). |
+| CPU/shm transport preserves all rows above with generation counter semantics | Open | None | None | Re-run the suite with `stream.transport "shm"` fixture: `cargo test -p nsi-stream --features shm transport_shm_parity`. |
+| 3Delight bridge: buckets upload into publication images, publication anchored to `Synchronized`/`Restarted` statuses | Open | None | None | `cargo test -p nsi-stream --features delight-bridge bridge_publication` with `DELIGHT` set; manual QA via viewport example. |
+
+## Invariants
+
+- Publication never blocks renderer progress (latest-wins).
+- The driver never writes an image with an outstanding lease.
+- Frame serial is strictly monotonic; scene generation is monotonic and
+  equals the count of applied synchronizes observed by the driver.
+- Pixel data is linear, scene-referred, in the layer's declared format at
+  every transport.
+
+## Failure Modes
+
+- Semaphore wait timeout on the client → surface as typed error with the
+  publication's serial; do not spin.
+- Driver allocation failure on resize → stream enters Failed, client
+  notified via channel close + typed message; renderer render continues per
+  `stream.onclientloss` semantics.
+- Client crash mid-lease → channel close ⇒ all leases considered released
+  after the driver's in-flight timeline value retires.
+
+## Required Evidence Before Marking Complete
+
+- Source evidence must cite `crates/nsi-stream/src/` symbols (ring,
+  publication, transport implementations) per row.
+- Executable evidence: the exact `cargo test` commands per row (never
+  `--release`); GPU rows additionally cite the validation-layer log or
+  sanitizer used.
+- Bridge row: requires 3Delight installed, `DELIGHT` set; cite renderer
+  version. Manual QA: run the viewport example, perform live edits +
+  synchronize, record observed atomicity (no mixed-state frame) and the
+  drop counter behavior.

--- a/specs/001-gpu-pixel-streaming/data-model.md
+++ b/specs/001-gpu-pixel-streaming/data-model.md
@@ -1,0 +1,82 @@
+# Data Model: GPU-Resident Pixel Streaming
+
+## Entities
+
+- **StreamConfig** -- decoded `stream.*` attribute set: version, transport,
+  publish mode, ring size, rendezvous channel, device UUID. Owner:
+  `nsi-stream` vocabulary parser.
+- **Layer** -- one connected `outputlayer`: name, `variablename`, pixel
+  format, channel count. Owner: driver.
+- **PublicationImage** -- one ring entry: extent, per-layer images (or array
+  layers), backing memory handle, last-write timeline value. Owner: driver.
+- **Publication** -- an announcement: image index, frame serial
+  (monotonic), scene generation (count of applied synchronizes), semaphore
+  value to wait on, extent. Owner: driver; consumed by client.
+- **AcquireToken** -- client lease on a PublicationImage; must be released.
+  Owner: client.
+- **Transport** -- `GpuShared` | `Shm` | `Callback`. Selected at open.
+
+## Lifecycle State Machine
+
+```text
+Configured --open()--> Open --first publication--> Streaming
+Streaming --resize edit + synchronize--> Resizing --all old released--> Streaming
+Streaming|Resizing --close()--> Draining --final semaphore value signaled--> Closed
+open() failure --> Failed (typed error, no partial state)
+```
+
+Rules:
+
+- open() validates version, transport viability, formats, and handles before
+  allocating; failure leaves nothing to clean up.
+- Resizing allocates a new ring at the new extent; pre-resize images are
+  reclaimed only on release.
+- Draining stops new publications, waits for the final timeline value, then
+  releases GPU objects. Client channel-close is treated as close().
+
+## Wire Format: Attribute Vocabulary (version 1)
+
+Set by the client on the `outputdriver` node; forwarded verbatim to the
+driver per the ɴsɪ spec.
+
+| Attribute | ɴsɪ type | Req. | Meaning |
+| --- | --- | --- | --- |
+| `drivername` | string | yes | `"nsi-stream"`. |
+| `stream.version` | int | yes | Vocabulary version; unsupported ⇒ typed open error. |
+| `stream.transport` | string | no | `"auto"` (default), `"gpu"`, `"shm"`, `"callback"`. |
+| `stream.publish` | string | no | `"commit"` (default) or `"continuous"`. |
+| `stream.ring` | int | no | Ring size, default 3, min 2. |
+| `stream.channel` | string | no | Rendezvous endpoint name (local socket) for cross-process handle export and publication messages. |
+| `stream.device.uuid` | string | no | Adapter UUID the client renders on; driver must match or fail/fall back per transport rules. |
+| `stream.callback.open` | pointer | no | In-process only: open notification closure. |
+| `stream.callback.publish` | pointer | no | In-process only: publication notification closure. |
+| `stream.callback.close` | pointer | no | In-process only: close notification closure. |
+| `stream.onclientloss` | string | no | `"continue"` (default) or `"stop"` -- renderer behavior when the client vanishes. |
+
+Direction of the reverse channel: the client only ever *sets attributes*
+(client → renderer, preserving unidirectional ɴsɪ dataflow); the driver
+initiates the reverse flow itself by connecting to `stream.channel` (or
+invoking the in-process closures), over which it sends: exported memory and
+semaphore handles at open/resize, then one Publication message per publish.
+
+Message framing on `stream.channel`, handle passing mechanics (e.g.
+`SCM_RIGHTS` on Unix), and the shm layout for the `shm` transport are
+version-1-frozen and documented with the implementation; any change bumps
+`stream.version`.
+
+## Ownership And Concurrency
+
+- Driver owns all GPU objects and the semaphore; the client owns only
+  leases (AcquireTokens) and its rendezvous endpoint.
+- The driver never writes an image with an outstanding lease; if no image is
+  free at publish time, the publication is dropped (latest-wins) and a drop
+  counter increments.
+- Bucket writers (renderer threads) synchronize among themselves before a
+  publication's semaphore value is signaled; the client only ever waits on
+  the timeline value from the Publication message.
+
+## Persistence And Migration
+
+No on-disk state. The wire contract is versioned by `stream.version`
+(R7): the driver rejects unknown versions loudly; the client rejects
+unknown message types loudly. No silent downgrade.

--- a/specs/001-gpu-pixel-streaming/plan.md
+++ b/specs/001-gpu-pixel-streaming/plan.md
@@ -31,8 +31,8 @@ shared-memory transport (`rustix`/equivalent), 3Delight bridge
 require 3Delight and `DELIGHT`; GPU tests run with validation layers where
 available.
 
-**Target Platform**: Linux and Windows first (Vulkan external memory +
-timeline semaphores); macOS deferred pending clarification.
+**Target Platform**: Linux first (Vulkan external memory FD), Windows next
+(Win32 handle variant); macOS deferred (Metal shared events/IOSurface).
 
 **Performance Goals**: acquire ≤ 100 µs and non-blocking; zero client-side
 CPU pixel copies on the GPU transport; bridge path at most one upload per
@@ -50,8 +50,9 @@ untouched for file/CPU consumers.
 - Evidence policy: both contract files include
   `Required Evidence Before Marking Complete`; all rows currently `Open`.
 - Scope: implementation sessions work one user story or contract row at a
-  time; three `[NEEDS CLARIFY]` markers in `spec.md` must be resolved via
-  `/clarify` before implementation starts.
+  time. All `[NEEDS CLARIFY]` markers were resolved 2026-07-26 (recorded
+  inline in `spec.md`): Vulkan/`ash` driver side, bridge in v1,
+  cross-process in v1, Linux → Windows → macOS.
 
 ## Project Structure
 

--- a/specs/001-gpu-pixel-streaming/plan.md
+++ b/specs/001-gpu-pixel-streaming/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: GPU-Resident Pixel Streaming
+
+**Branch**: `claude/nsi-api-realtime-2okw3y` | **Date**: `2026-07-26` |
+**Spec**: `specs/001-gpu-pixel-streaming/spec.md`.
+
+## Summary
+
+Define and implement a renderer-agnostic pixel streaming contract for ɴsɪ,
+carried entirely by `stream.*` attributes on the standard `outputdriver`
+node, so rendered pixels can stay GPU-resident. Ship it as a new
+`nsi-stream` crate with a driver-owned publication ring, timeline-semaphore
+synchronization, negotiated transports (gpu-shared/shm/callback), and a
+3Delight bridge so the contract is testable against the only existing ɴsɪ
+renderer.
+
+## Technical Context
+
+**Language/Version**: Rust, workspace edition/toolchain as pinned by the
+root `Cargo.toml`.
+
+**Primary Dependencies**: `nsi-trait` (only mandatory internal dep).
+Feature-gated: Vulkan backend (`ash` or `wgpu` -- open clarification),
+shared-memory transport (`rustix`/equivalent), 3Delight bridge
+(`nsi-sys`/ndspy internals, feature `delight-bridge`).
+
+**Storage**: none on disk. Wire surfaces: the attribute vocabulary and the
+`stream.channel` message framing + shm layout, versioned by
+`stream.version` (see `data-model.md`).
+
+**Testing**: `cargo test -p nsi-stream` (never `--release`); bridge tests
+require 3Delight and `DELIGHT`; GPU tests run with validation layers where
+available.
+
+**Target Platform**: Linux and Windows first (Vulkan external memory +
+timeline semaphores); macOS deferred pending clarification.
+
+**Performance Goals**: acquire ≤ 100 µs and non-blocking; zero client-side
+CPU pixel copies on the GPU transport; bridge path at most one upload per
+bucket.
+
+**Constraints**: no changes to the ɴsɪ call/node set (R1); `nsi-ffi-wrap`
+gains no mandatory GPU dependencies (R9); existing `output` module remains
+untouched for file/CPU consumers.
+
+## Constitution Check
+
+- Source-of-truth: `.specify/feature.json` →
+  `specs/001-gpu-pixel-streaming`.
+- Required artifacts: all eight present in this directory.
+- Evidence policy: both contract files include
+  `Required Evidence Before Marking Complete`; all rows currently `Open`.
+- Scope: implementation sessions work one user story or contract row at a
+  time; three `[NEEDS CLARIFY]` markers in `spec.md` must be resolved via
+  `/clarify` before implementation starts.
+
+## Project Structure
+
+```text
+specs/001-gpu-pixel-streaming/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── checklists/
+│   └── requirements.md
+└── contracts/
+    ├── attribute-vocabulary.md
+    └── publication-lifecycle.md
+
+crates/nsi-stream/            (new, this feature)
+├── src/
+│   ├── lib.rs                vocabulary parser, errors, config
+│   ├── ring.rs               publication ring, acquire/release
+│   ├── transport/            gpu.rs, shm.rs, callback.rs
+│   └── bridge/               3Delight bridge (feature delight-bridge)
+└── tests/                    contract-derived tests
+examples/stream_viewport/     manual-QA path (winit + GPU blit)
+```
+
+## Execution Rules
+
+1. Resolve the three `[NEEDS CLARIFY]` markers before implementation.
+2. Work one user story or one contract row at a time.
+3. Add or update tests from the contract invariants before ticking rows.
+4. Mark rows `Covered` only after the listed evidence commands ran.
+
+## Artifact Checklist
+
+- [x] Active feature pointer is updated (`.specify/feature.json`).
+- [x] Required artifact set exists.
+- [x] Each contract file has `Required Evidence Before Marking Complete`.

--- a/specs/001-gpu-pixel-streaming/quickstart.md
+++ b/specs/001-gpu-pixel-streaming/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: GPU-Resident Pixel Streaming
+
+**Current status: spec only.** `crates/nsi-stream` does not exist yet; the
+commands below are the verification path once tasks in `tasks.md` land.
+Nothing here is evidence until it has actually been run.
+
+## Build And Test
+
+```bash
+# Contract-derived tests (no GPU required for vocabulary/ring rows).
+cargo test -p nsi-stream
+
+# GPU transport rows (Vulkan validation layers recommended).
+cargo test -p nsi-stream --features vulkan
+
+# Shm transport parity.
+cargo test -p nsi-stream --features shm
+
+# 3Delight bridge rows (requires 3Delight installed and DELIGHT set).
+cargo test -p nsi-stream --features delight-bridge
+```
+
+Never use `--release` for these (repo rule, see `AGENTS.md`).
+
+## Manual QA Path
+
+1. Run the viewport example against a renderer (bridge or native backend):
+
+   ```bash
+   cargo run --example stream_viewport --features vulkan,delight-bridge
+   ```
+
+2. Confirm the window shows the progressive render and the overlay reports
+   transport `gpu`, publish mode, frame serial, scene generation, and drop
+   counter.
+3. Perform live edits (the example binds keys to transform/light edits that
+   call `synchronize`). Confirm in `commit` mode that no displayed frame
+   mixes old and new state, and the generation counter increments per
+   synchronize.
+4. Resize the window (triggers a `screen` resolution edit + synchronize).
+   Confirm publication continues at the new extent with no crash.
+5. Kill the viewer while rendering; confirm renderer behavior matches
+   `stream.onclientloss` and no validation-layer errors are logged.
+
+Record renderer name/version, OS, GPU, and observed results when citing this
+path as contract evidence.

--- a/specs/001-gpu-pixel-streaming/research.md
+++ b/specs/001-gpu-pixel-streaming/research.md
@@ -91,6 +91,39 @@ with a typed error.
 identifiers is forbidden. Auto-negotiation is opt-in, so a client that
 requires GPU residency finds out at open(), not from a profiler.
 
+## D7: Shading Direction For The Realtime Backend (Decided 2026-07-26)
+
+**Decision.** The future realtime backend translates ɴsɪ shader *networks*
+into portable GPU code (SPIR-V/WGSL) against a fixed closure vocabulary --
+the MaterialX-shadergen-shaped approach -- rather than executing arbitrary
+ᴏsʟ on the GPU. Closures remain the shading/integrator boundary; the
+supported node and closure set becomes its own contract surface (see
+`specs/README.md` coverage order).
+
+**Why.** ᴏsʟ's only GPU backend is the upstream LLVM-to-PTX/OptiX path
+(Sony Imageworks + NVIDIA; production-proven in Arnold GPU, Cycles, and
+Isotropix's Angie before the company folded) -- NVIDIA-only. No SPIR-V
+backend exists, and the hard part of writing one is the runtime contract
+(`texture()`, `trace()`, `getattribute()`, ustrings as renderer callbacks),
+not codegen. Network translation is cross-vendor today and matches how ɴsɪ
+is actually used: shader nodes form networks, and ɴsɪ's lights are emissive
+shaders, so the translated profile must include `emission()`.
+
+**Cost.** Arbitrary hand-written ᴏsʟ does not run on the realtime backend;
+it remains available via offline renderers (3Delight) through the same ɴsɪ
+scene. The closure/node vocabulary must be versioned and contracted.
+
+**Rejected.** (A) NVIDIA-only OptiX reuse -- proven but vendor-locked and
+drags CUDA interop into the transport. (C) Writing an ᴏsʟ→SPIR-V backend --
+the correct long-term answer, rejected for scope: runtime-callback design
+dwarfs this feature. (D) CPU shading with GPU display only -- zero shading
+compromise but concedes the realtime goal; remains the fallback posture via
+the bridge.
+
+**Consequence for this feature.** None on the wire contract; it resolved
+the first open clarification (Vulkan/`ash` driver side, no CUDA interop
+requirement).
+
 ## References
 
 - ɴsɪ spec, `outputdriver` node: <https://nsi.readthedocs.io/en/latest/nodes/outputdriver.html>

--- a/specs/001-gpu-pixel-streaming/research.md
+++ b/specs/001-gpu-pixel-streaming/research.md
@@ -1,0 +1,103 @@
+# Research: GPU-Resident Pixel Streaming
+
+Decisions, rejected alternatives, and references. Investigation summary from
+the session that produced this spec: the ɴsɪ interface is already
+interactive by design (buffered edits applied atomically at
+`RenderControl(synchronize)`); the pixel return path is the most incidental
+of its realtime gaps because the driver API is explicitly outside the spec.
+
+## D1: Attribute-Only Contract On The `outputdriver` Node
+
+**Decision.** Express the whole contract as `drivername "nsi-stream"` plus
+`stream.*` attributes on the standard `outputdriver` node.
+
+**Why.** The ɴsɪ spec states the destination "could be a file ... frame
+buffer or a memory address", that the driver API "is implementation specific
+and is not covered by this documentation", and that "any extra attributes
+are also forwarded to the output driver which may interpret them however it
+wishes". A conforming renderer that does not know the vocabulary simply has
+no driver named `nsi-stream` and errors accordingly.
+
+**Rejected.** New ɴsɪ calls or node types -- breaks the twelve-call surface
+and portability for zero gain. Extending ndspy -- ndspy is 3Delight's
+RenderMan-era artifact, pull-based, CPU-bucket-shaped; not a contract worth
+inheriting.
+
+## D2: Driver-Owned Publication Ring ("Reverse Swapchain")
+
+**Decision.** The driver allocates and owns 2--3 publication images; the
+client acquires the latest published one and releases it. Publication is
+latest-wins and never blocks the renderer.
+
+**Why.** Renderer-side ownership makes resize a driver-internal reallocation
+(old images drain via release), keeps write-safety trivial (never write a
+held image), and mirrors how progressive accumulation already works
+renderer-side.
+
+**Rejected.** Client-allocated surfaces the renderer imports -- complicates
+resize and forces the client to reason about renderer write timing. A
+single shared surface -- guarantees tearing or forces renderer stalls.
+
+## D3: OS Handles, Not Pointers
+
+**Decision.** GPU objects cross the boundary as exportable handles (POSIX FD
+/Win32 handle for memory, timeline semaphore handles) plus a device UUID for
+adapter matching. In-process transport may shortcut with closures, matching
+the existing `callback!` and `reference!` precedent in `nsi-ffi-wrap`.
+
+**Why.** Handles survive process boundaries on the same host and GPU; raw
+pointers do not. Pointer attributes also destroy the serializability design
+goal wherever they appear, so they are confined to the transport that is
+unserializable anyway.
+
+**Rejected.** Raw pointer attributes as the primary contract.
+
+## D4: Publication Anchored To `synchronize`
+
+**Decision.** `commit` mode publishes atomically per applied synchronize,
+tagged with a scene generation; `continuous` mode additionally publishes
+during refinement. Default: `commit` for engines, `continuous` for DCC IPR.
+
+**Why.** `RenderControl` is the API's single transaction point -- edits are
+buffered and applied atomically at synchronize (statuses `Synchronized`/
+`Restarted`). Anchoring publication to that boundary gives an engine a
+frame-state/image correlation for free.
+
+**Rejected.** Renderer-cadence-only pushing -- the client cannot correlate
+an image with the scene state that produced it.
+
+## D5: New Crate `nsi-stream`
+
+**Decision.** The contract types, vocabulary parser, transports, and the
+3Delight bridge (feature `delight-bridge`) live in a new crate depending
+only on `nsi-trait`. GPU backends are feature-gated.
+
+**Why.** `nsi-ffi-wrap/src/output/` is bound to 3Delight's ndspy driver and
+CPU bucket delivery; it stays for file output and CPU consumers. The stream
+contract must be implementable by any renderer, including a future
+`Nsi`-trait backend exposed via `FfiApiAdapter` -- which would implement the
+sink natively and never touch ndspy.
+
+**Rejected.** Growing the existing `output` module -- entangles a
+renderer-agnostic contract with an ndspy-specific one.
+
+## D6: Loud Failure, Negotiated Fallback
+
+**Decision.** `stream.transport "auto"` negotiates gpu-shared, then shared
+memory, then callback. Any explicitly named transport that cannot open fails
+with a typed error.
+
+**Why.** Blueprints persistence rule: silent fallback on required
+identifiers is forbidden. Auto-negotiation is opt-in, so a client that
+requires GPU residency finds out at open(), not from a profiler.
+
+## References
+
+- ɴsɪ spec, `outputdriver` node: <https://nsi.readthedocs.io/en/latest/nodes/outputdriver.html>
+- ɴsɪ spec, rendering/`RenderControl`: <https://nsi.readthedocs.io/en/latest/c-api.html>
+- ɴsɪ design goals: <https://nsi.readthedocs.io/en/latest/background.html>
+- Existing CPU driver wrapper: `crates/nsi-ffi-wrap/src/output/mod.rs`
+- Zero-copy precedent: `crates/nsi-ffi-wrap/src/argument.rs` (`Reference`,
+  `ReferenceSlice`)
+- Backend-independence machinery: `crates/nsi-trait/src/nsi_trait.rs`,
+  `crates/nsi-ffi-wrap/src/c_api.rs` (`FfiApiAdapter`)

--- a/specs/001-gpu-pixel-streaming/spec.md
+++ b/specs/001-gpu-pixel-streaming/spec.md
@@ -1,0 +1,161 @@
+# Feature Spec: GPU-Resident Pixel Streaming
+
+Replace the ndspy-style CPU bucket callback path with a renderer-agnostic
+pixel streaming contract that lets rendered pixels stay GPU-side. ndspy is a
+historical RenderMan artifact of 3Delight, not part of ɴsɪ -- the ɴsɪ spec
+only standardizes the `outputdriver` node and explicitly leaves the driver
+API to the implementation, forwarding any extra attributes to it. This
+feature defines that contract for the Rust ecosystem.
+
+## User Stories
+
+### User Story 1: DCC Viewport Without CPU Round-Trip (P1)
+
+As a DCC/viewport integrator, I want progressive render output delivered
+into a GPU texture I can sample directly, so that displaying an interactive
+render costs no pixel copy through my application's CPU memory.
+
+**Acceptance Criteria**
+
+- Given an interactive render with the stream output driver in-process, when
+  the renderer publishes an update, then the client can acquire a texture
+  containing the published image without any client-side CPU pixel copy.
+- Given a running stream, when the client calls acquire, then the call
+  returns without blocking on renderer progress (latest published image or
+  "nothing new").
+- Given a publication, when the client samples the acquired texture after
+  waiting on its fence/semaphore value, then the contents are complete (no
+  partially written bucket).
+
+### User Story 2: Atomic Frame Handoff For Engines (P1)
+
+As a game-engine integrator, I want each `RenderControl` `synchronize`
+commit to map to identifiable, atomic publications, so that no displayed
+frame mixes pixels from two scene states.
+
+**Acceptance Criteria**
+
+- Given publish mode `commit`, when edits are synchronized, then every
+  subsequently acquired image is tagged with the scene generation it was
+  rendered from, and contains samples from exactly one generation.
+- Given publish mode `continuous`, when buckets accumulate, then acquired
+  images may show partial refinement of one generation but never contain a
+  torn (partially written) bucket.
+- Given the client holds all ring images, when the renderer wants to
+  publish, then the renderer does not stall; the publication is dropped,
+  latest-wins, and a drop counter is incremented.
+
+### User Story 3: Degradation To CPU Transport (P2)
+
+As a client of an out-of-process renderer, I want the same client code to
+fall back to a shared-memory/CPU transport, so that GPU residency is an
+optimization, not a protocol fork.
+
+**Acceptance Criteria**
+
+- Given `stream.transport` `"auto"` and no viable GPU path, when the driver
+  opens, then pixels arrive via the shared-memory transport and the
+  client-facing acquire API is unchanged.
+- Given an explicitly requested transport that is not viable, when the
+  driver opens, then opening fails with a typed error -- no silent fallback.
+
+### User Story 4: AOV Mapping (P2)
+
+As a client, I want each connected `outputlayer` addressable as its own
+texture (or array layer), so that multi-AOV pipelines (beauty, ID picking,
+normals) work without demultiplexing on the CPU.
+
+**Acceptance Criteria**
+
+- Given N output layers connected to one stream driver, when acquiring a
+  publication, then each layer is individually addressable with its declared
+  format and `variablename`.
+
+### User Story 5: Resolution Change Safety (P3)
+
+As a client, I want a `screen` resolution edit followed by `synchronize` to
+resize the stream safely, so that interactive quality scaling (drop
+resolution while dragging) never crashes or leaks.
+
+**Acceptance Criteria**
+
+- Given a resolution edit and synchronize, when the next publication occurs,
+  then it uses the new extent.
+- Given the client still holds a pre-resize acquisition, when the resize
+  happens, then that acquisition stays valid until released; images are
+  reclaimed only after release (no use-after-free).
+
+## Non-Goals
+
+- A realtime renderer backend (`Nsi` trait implementation) -- separate
+  feature (see `specs/README.md` coverage order).
+- Input-side GPU residency (geometry/attribute buffers via `Reference`-style
+  handoff) -- separate feature.
+- Frame pacing/deadline contracts and temporal-reuse semantics across
+  `synchronize` -- renderer-side, separate feature.
+- Tone mapping or display transforms -- the stream stays linear,
+  scene-referred; display transform is the client's post stack.
+- Cross-host (network) transport of GPU surfaces. The serializable-stream
+  use of ɴsɪ degrades to the CPU transport; that is by design.
+- ndspy as a public API. It may appear only inside a 3Delight bridge
+  implementation detail.
+
+## Requirements
+
+- R1: The contract is expressed entirely as attributes on the standard
+  `outputdriver` node (`drivername "nsi-stream"` plus a `stream.*`
+  vocabulary). No additions to the ɴsɪ call set or node set.
+- R2: GPU resources cross the client/renderer boundary only as exportable,
+  named OS handles (external memory, timeline semaphores) -- never as raw
+  pointers. Raw pointers/closures are permitted only for the in-process
+  callback transport, matching existing `callback!`/`reference!` precedent.
+- R3: The driver owns a ring of at least 2 publication images. Clients
+  acquire and release; the driver never writes an image a client holds.
+- R4: GPU synchronization uses one timeline semaphore (or platform
+  equivalent); each publication carries the semaphore value to wait on. The
+  CPU transport uses a generation counter/seqlock equivalent.
+- R5: Publish modes: `commit` (atomic publication per applied synchronize)
+  and `continuous` (progressive accumulation visible between commits).
+- R6: Minimum formats: RGBA f16 and f32; per-layer format declared per
+  `outputlayer`. Pixel data is linear and scene-referred.
+- R7: Version negotiation: `stream.version` is mandatory; an unsupported
+  version fails open() with a typed error.
+- R8: Failure is loud (typed errors) for unviable transports, bad handles,
+  and version mismatch. Fallback happens only under `"auto"`.
+- R9: Rust surface lives in a new `nsi-stream` crate depending on
+  `nsi-trait` only; GPU backends are feature-gated so `nsi-ffi-wrap` and
+  clients without GPU needs take no graphics dependencies.
+- R10: A 3Delight bridge implements the contract against today's only ɴsɪ
+  renderer by uploading its display-driver buckets into the publication
+  images, preserving publication semantics. [NEEDS CLARIFY: is the bridge
+  v1 scope, or does v1 target only a future Rust backend? Bridge-in-v1
+  makes the contract testable against a real renderer now.]
+
+## Open Clarifications
+
+- [NEEDS CLARIFY: first GPU backend -- raw Vulkan via `ash`, `wgpu`
+  (external-memory import support varies per backend), or Vulkan-first with
+  a `wgpu` interop layer?]
+- [NEEDS CLARIFY: is cross-process/same-GPU (handle export over a local
+  socket) in v1, or is v1 in-process only with the vocabulary designed so
+  cross-process adds later without breakage?]
+- [NEEDS CLARIFY: platform priority -- Linux/Windows (Vulkan external
+  memory) first, macOS (Metal shared events/IOSurface) later?]
+
+## Risks
+
+- `wgpu` cannot import external memory on all backends. Mitigation: keep the
+  transport pluggable; treat backend choice as a clarification, not an
+  assumption.
+- Handle lifetime across the FFI boundary (renderer thread writing after
+  client teardown, or vice versa). Mitigation: explicit lifecycle state
+  machine (`data-model.md`), close protocol that waits on the final
+  semaphore value, channel-close detection.
+- 3Delight's display-driver thread model delivers buckets from many threads.
+  Mitigation: the bridge serializes uploads per image; covered by bridge
+  contract rows.
+- Semaphore deadlock. Mitigation: timeline (not binary) semaphores;
+  publication never waits on client acquisition (latest-wins, R3/US2).
+- Vocabulary drift between renderers. Mitigation: contract-first -- the
+  vocabulary table in `data-model.md` is the wire format of record and is
+  versioned (R7).

--- a/specs/001-gpu-pixel-streaming/spec.md
+++ b/specs/001-gpu-pixel-streaming/spec.md
@@ -127,20 +127,24 @@ resolution while dragging) never crashes or leaks.
   clients without GPU needs take no graphics dependencies.
 - R10: A 3Delight bridge implements the contract against today's only ɴsɪ
   renderer by uploading its display-driver buckets into the publication
-  images, preserving publication semantics. [NEEDS CLARIFY: is the bridge
-  v1 scope, or does v1 target only a future Rust backend? Bridge-in-v1
-  makes the contract testable against a real renderer now.]
+  images, preserving publication semantics. RESOLVED (2026-07-26): the
+  bridge is v1 scope -- the contract must be testable against a real
+  renderer from the start.
 
 ## Open Clarifications
 
-- [NEEDS CLARIFY: first GPU backend -- raw Vulkan via `ash`, `wgpu`
-  (external-memory import support varies per backend), or Vulkan-first with
-  a `wgpu` interop layer?]
-- [NEEDS CLARIFY: is cross-process/same-GPU (handle export over a local
-  socket) in v1, or is v1 in-process only with the vocabulary designed so
-  cross-process adds later without breakage?]
-- [NEEDS CLARIFY: platform priority -- Linux/Windows (Vulkan external
-  memory) first, macOS (Metal shared events/IOSurface) later?]
+- RESOLVED (2026-07-26): first GPU backend is Vulkan via `ash` on the
+  driver side, with a `wgpu-hal` interop helper for clients. Follows from
+  the shading direction decision (`research.md` D7): cross-vendor network
+  translation removes any CUDA/OptiX interop requirement, and `ash` is the
+  only stable Rust path to external memory + timeline semaphores.
+- RESOLVED (2026-07-26): cross-process/same-GPU is v1 scope -- the
+  `stream.channel` rendezvous with handle export ships in v1 and proves the
+  degradation story immediately (US3 is promoted to v1 alongside US1/US2).
+- RESOLVED (2026-07-26): platform priority is Linux first (Vulkan external
+  memory FD path), Windows next (Win32 handle variant), macOS deferred to
+  its own task (Metal shared events/IOSurface is a materially different
+  implementation).
 
 ## Risks
 

--- a/specs/001-gpu-pixel-streaming/tasks.md
+++ b/specs/001-gpu-pixel-streaming/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: GPU-Resident Pixel Streaming
+
+Dependency-ordered. Every task is small enough for a single commit and names
+its evidence gate. Nothing may be ticked before its evidence ran (see
+contracts). Tasks T1--T3 are blocked on the `/clarify` pass resolving the
+three `[NEEDS CLARIFY]` markers in `spec.md`.
+
+## Setup
+
+- [ ] T1: Resolve `[NEEDS CLARIFY]` markers (GPU backend, bridge-in-v1,
+  platform priority) and record answers in `spec.md`. Evidence: updated
+  spec with markers removed.
+- [ ] T2: Scaffold `crates/nsi-stream` (lib, error types, features:
+  `vulkan`, `shm`, `delight-bridge`), wire into workspace. Evidence:
+  `cargo build -p nsi-stream`.
+- [ ] T3: Freeze the version-1 vocabulary table and channel/shm framing in
+  `data-model.md` after clarifications. Evidence: `/analyze` pass shows no
+  drift between spec, data-model, and contracts.
+
+## User Story 1 -- DCC Viewport Without CPU Round-Trip (P1)
+
+- [ ] T4: Vocabulary parser + typed errors (rows 1--3 of
+  `attribute-vocabulary.md`). Evidence: `vocabulary_forwarding`,
+  `vocabulary_version_reject`, `vocabulary_unknown_attr_warns`.
+- [ ] T5: Publication ring with acquire/release and latest-wins drop
+  (`ring.rs`). Evidence: `acquire_nonblocking`, `ring_exhaustion_drops`,
+  `release_reuse_ordering`.
+- [ ] T6: In-process GPU transport (allocation, timeline semaphore,
+  publication signaling). Evidence: `publication_semaphore_complete` with
+  validation layers.
+- [ ] T7: `examples/stream_viewport` -- window, blit acquired texture,
+  status overlay. Evidence: manual QA path in `quickstart.md`.
+
+## User Story 2 -- Atomic Frame Handoff (P1)
+
+- [ ] T8: Scene-generation tagging anchored to synchronize
+  (`Synchronized`/`Restarted` statuses). Evidence:
+  `publish_commit_atomic`.
+- [ ] T9: `continuous` mode with per-bucket write fencing. Evidence:
+  `publish_continuous_no_torn_bucket`.
+
+## User Story 3 -- CPU/Shm Degradation (P2)
+
+- [ ] T10: Transport negotiation (`auto` order, explicit-no-fallback,
+  device-UUID check). Evidence: `transport_auto_negotiation`,
+  `transport_explicit_no_fallback`, `transport_device_mismatch`.
+- [ ] T11: Shm transport with generation-counter parity. Evidence:
+  `transport_shm_parity`.
+- [ ] T12: `stream.channel` rendezvous (handle export, publication
+  messages, client-loss detection). Evidence: `client_loss_behavior`.
+
+## User Story 4 -- AOV Mapping (P2)
+
+- [ ] T13: Per-`outputlayer` targets with declared formats. Evidence:
+  `layer_formats` plus multi-AOV manual QA.
+
+## User Story 5 -- Resize Safety (P3)
+
+- [ ] T14: Resize ring reallocation with drain-on-release. Evidence:
+  `resize_drain_safety`.
+- [ ] T15: Close/drain protocol. Evidence: `close_drain`.
+
+## Bridge (gated on T1 outcome)
+
+- [ ] T16: 3Delight bridge -- ndspy-internal driver uploading buckets into
+  publication images. Evidence: `bridge_publication` with `DELIGHT` set;
+  viewport-example manual QA against 3Delight.

--- a/specs/001-gpu-pixel-streaming/tasks.md
+++ b/specs/001-gpu-pixel-streaming/tasks.md
@@ -2,14 +2,14 @@
 
 Dependency-ordered. Every task is small enough for a single commit and names
 its evidence gate. Nothing may be ticked before its evidence ran (see
-contracts). Tasks T1--T3 are blocked on the `/clarify` pass resolving the
-three `[NEEDS CLARIFY]` markers in `spec.md`.
+contracts).
 
 ## Setup
 
-- [ ] T1: Resolve `[NEEDS CLARIFY]` markers (GPU backend, bridge-in-v1,
-  platform priority) and record answers in `spec.md`. Evidence: updated
-  spec with markers removed.
+- [x] T1: Resolve `[NEEDS CLARIFY]` markers (GPU backend, bridge-in-v1,
+  cross-process scope, platform priority) and record answers in `spec.md`.
+  Evidence: `spec.md` contains no `[NEEDS CLARIFY]` markers; four RESOLVED
+  entries dated 2026-07-26.
 - [ ] T2: Scaffold `crates/nsi-stream` (lib, error types, features:
   `vulkan`, `shm`, `delight-bridge`), wire into workspace. Evidence:
   `cargo build -p nsi-stream`.
@@ -39,7 +39,7 @@ three `[NEEDS CLARIFY]` markers in `spec.md`.
 - [ ] T9: `continuous` mode with per-bucket write fencing. Evidence:
   `publish_continuous_no_torn_bucket`.
 
-## User Story 3 -- CPU/Shm Degradation (P2)
+## User Story 3 -- CPU/Shm Degradation (promoted to v1, 2026-07-26)
 
 - [ ] T10: Transport negotiation (`auto` order, explicit-no-fallback,
   device-UUID check). Evidence: `transport_auto_negotiation`,
@@ -60,7 +60,7 @@ three `[NEEDS CLARIFY]` markers in `spec.md`.
   `resize_drain_safety`.
 - [ ] T15: Close/drain protocol. Evidence: `close_drain`.
 
-## Bridge (gated on T1 outcome)
+## Bridge (v1 scope per T1 resolution)
 
 - [ ] T16: 3Delight bridge -- ndspy-internal driver uploading buckets into
   publication images. Evidence: `bridge_publication` with `DELIGHT` set;

--- a/specs/002-shading-profile/checklists/requirements.md
+++ b/specs/002-shading-profile/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Requirements Checklist: Shading Profile
+
+Ticked items cite the document that satisfies them; everything else stays
+unticked until its evidence exists.
+
+## Spec Quality
+
+- [x] User stories are independently testable (`spec.md` -- each has its
+  own contract rows and commands).
+- [x] Acceptance criteria are observable (`spec.md` -- validation reports,
+  image-comparison metrics, exit codes).
+- [x] Non-goals are explicit (`spec.md` "Non-Goals", normative
+  excluded-construct list).
+- [x] Risks are named (`spec.md` "Risks").
+- [ ] All `[NEEDS CLARIFY]` markers resolved (3 remain: v1 closure list,
+  MaterialX nodedefs vs native, WGSL target -- blocked on `/clarify`).
+
+## Contract Quality
+
+- [x] Every important behavior has a contract row
+  (`contracts/profile-conformance.md`).
+- [x] Every row is `Covered`, `Partial`, or `Open` (all currently `Open`).
+- [ ] `Covered` rows cite source evidence (none yet -- no implementation).
+- [ ] `Covered` rows cite test or manual QA evidence (none yet).
+- [x] Required evidence is listed before work starts (contract file).
+
+## Implementation Readiness
+
+- [ ] Tasks are small enough for single commits (`tasks.md` drafted;
+  verify during `/analyze` after clarifications).
+- [x] Persistence and migration behavior is documented (`data-model.md` --
+  versioned scheme + ParameterBlock wire format, no disk state).
+- [x] Shared logic ownership is named (`nsi-profile` crate owns both
+  targets; `research.md` D1, constitution VII).

--- a/specs/002-shading-profile/contracts/profile-conformance.md
+++ b/specs/002-shading-profile/contracts/profile-conformance.md
@@ -1,0 +1,51 @@
+# Contract: Profile Conformance And Parity
+
+## Scope
+
+This contract covers profile versioning, validation, translation outputs,
+and offline/realtime parity. It does not cover integrator behavior
+(sampling, MIS, denoising) or the pixel-streaming transport (feature 001).
+
+## Matrix
+
+| Behavior | Status | Source Evidence | Test/QA Evidence | Required Next Evidence |
+| --- | --- | --- | --- | --- |
+| `nsi-profile:<node>@<version>` resolution on standard `shader` nodes; unknown node/version fails loudly | Open | None | None | `cargo test -p nsi-profile resolve_scheme`. |
+| Validator reports out-of-profile constructs with node handle + construct + version (US3) | Open | None | None | `cargo test -p nsi-profile validator_violations`; CI run on fixture scenes. |
+| Conforming fixture scenes validate clean | Open | None | None | `cargo test -p nsi-profile validator_clean`. |
+| Every v1 NodeDef has both an ᴏsʟ reference and a GPU emitter | Open | None | None | `cargo test -p nsi-profile nodedef_completeness` (walks the registry). |
+| Per-node parity: ᴏsʟ reference vs GPU translation within declared per-fixture tolerance (US2) | Open | None | None | Image-comparison harness vs 3Delight renders of fixture scenes (`DELIGHT` set); thresholds declared per fixture. |
+| Emission parity for each documented ɴsɪ light pattern (US4) | Open | None | None | Same harness, light-rig fixtures (area, spot, point, directional, HDR environment). |
+| ParameterBlock layout deterministic and stable within a profile version (R6) | Open | None | None | `cargo test -p nsi-profile parameter_block_layout` golden-file test. |
+| Parameter edits update ParameterBlocks without re-translation; topology edits re-translate | Open | None | None | `cargo test -p nsi-profile edit_classification`. |
+| MaterialX import maps the documented subset and validates (US5) | Open | None | None | `cargo test -p nsi-profile --features materialx mtlx_roundtrip` on sample documents. |
+
+## Invariants
+
+- No new ɴsɪ API calls or node types; the profile rides on `shader` nodes,
+  attributes, and connections.
+- Closures are the only shading/integrator interface; `emission` is part of
+  every profile version (ɴsɪ has no light nodes).
+- The excluded-construct list (`spec.md` Non-Goals) is normative; the
+  validator rejects, never silently strips.
+- Parity tolerances are declared per fixture in-repo, not chosen at test
+  time.
+
+## Failure Modes
+
+- Unknown profile node/version → typed resolution error naming the handle.
+- Out-of-profile network reaching the translator → translator refuses
+  (validation is not optional in the pipeline).
+- Parity regression beyond tolerance → CI failure listing fixture, node,
+  and metric; expected-image updates require explicit human approval
+  (constitution, review gates).
+
+## Required Evidence Before Marking Complete
+
+- Source evidence must cite `crates/nsi-profile/src/` symbols (registry,
+  validator, translator, emitters) per row.
+- Executable evidence: exact `cargo test -p nsi-profile <name>` commands
+  (never `--release`); parity rows additionally cite the harness command,
+  3Delight version, fixture names, and thresholds.
+- Manual QA evidence (if any row falls back to it): exact steps,
+  environment, and observed metrics.

--- a/specs/002-shading-profile/data-model.md
+++ b/specs/002-shading-profile/data-model.md
@@ -1,0 +1,54 @@
+# Data Model: Shading Profile
+
+## Entities
+
+- **Profile** -- a version: the definitive set of NodeDefs and ClosureDefs.
+  Owner: `nsi-profile` crate (name tentative, see `plan.md`).
+- **ClosureDef** -- name, parameters (types, units, ranges), semantic
+  reference (which BSDF/behavior, normalization). E.g. `emission`,
+  `diffuse`, `microfacet`.
+- **NodeDef** -- name, input/output ports with types and defaults, ᴏsʟ
+  reference implementation, GPU emitter. Pattern/utility/material nodes.
+- **Network** -- the ɴsɪ-side shader graph: `shader` nodes addressing
+  profile NodeDefs via the `nsi-profile:<node>@<version>` scheme (R7),
+  connected with standard `NSIConnect`.
+- **NetworkModule** -- translation output: SPIR-V module + ParameterBlock
+  layout + closure signature (which closures this network can emit).
+- **ParameterBlock** -- versioned, documented layout of animatable
+  parameters for a translated network (R6). This is a wire format.
+- **ValidationReport** -- per-scene: conforming | violations
+  (node handle, construct, profile version consulted).
+
+## Translation Pipeline
+
+```text
+NSI shader nodes + connections
+  --resolve NodeDefs (version check)--> Network
+  --validate (US3)--> ValidationReport
+  --translate--> NetworkModule (SPIR-V + ParameterBlock layout)
+  --parameter edits only--> ParameterBlock update (no re-translation)
+  --topology edits (connect/disconnect)--> re-translate
+```
+
+The parameter/topology split mirrors ɴsɪ's own edit model: attribute edits
+are cheap and frequent; structural edits are transactions.
+
+## Wire Formats
+
+- `shaderfilename` scheme: `"nsi-profile:<node>@<version>"` on standard
+  `shader` nodes; shader parameters remain ordinary ɴsɪ attributes. No new
+  node types, no new API calls.
+- ParameterBlock layout: std430-compatible, field order = declaration order
+  of the NodeDef parameters actually referenced; layout documented per
+  profile version and stable within it.
+- Profile version: semantic-versioned; a network validated against version
+  N must validate against N.x. Unknown versions fail loudly (R1).
+
+## Ownership And Migration
+
+- The profile crate owns NodeDefs, ClosureDefs, ᴏsʟ references, emitters,
+  and the validator. Backends consume NetworkModules; offline renderers
+  consume the ᴏsʟ references. One owner, two targets (constitution VII).
+- Version bumps: additive changes (new nodes/closures) are minor; any
+  change to existing semantics, parameters, or ParameterBlock layout is
+  major. No silent migration -- the validator names the required version.

--- a/specs/002-shading-profile/plan.md
+++ b/specs/002-shading-profile/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Shading Profile
+
+**Branch**: `claude/nsi-api-realtime-2okw3y` | **Date**: `2026-07-26` |
+**Spec**: `specs/002-shading-profile/spec.md`.
+
+## Summary
+
+Define the versioned closure/node vocabulary for realtime ɴsɪ shading and
+implement it as dual-target node definitions: ᴏsʟ references for offline
+renderers and SPIR-V emitters for realtime backends, with a loud validator
+and an image-comparison parity harness against 3Delight. Sketch status:
+this surface is specced second but implemented after feature 001; three
+`[NEEDS CLARIFY]` markers gate implementation.
+
+## Technical Context
+
+**Language/Version**: Rust, workspace toolchain. ᴏsʟ sources for the
+reference implementations.
+
+**Primary Dependencies**: `nsi-trait`; SPIR-V emission (`rspirv` or
+MaterialX shadergen + glslang, pending R3/R4); optional `materialx` feature
+for interchange (US5); 3Delight + `DELIGHT` for parity renders.
+
+**Storage**: none on disk beyond fixtures. Wire surfaces: the
+`nsi-profile:<node>@<version>` scheme and the ParameterBlock layout
+(`data-model.md`), semantic-versioned.
+
+**Testing**: `cargo test -p nsi-profile` (never `--release`); parity via
+the repo's expected-image machinery (`RUST_TEST_UPDATE=1` gated on human
+approval).
+
+**Target Platform**: platform-neutral (SPIR-V artifacts); parity harness
+runs where 3Delight runs (Linux first, matching feature 001).
+
+**Performance Goals**: parameter edits must not trigger re-translation
+(R6/edit classification); translation itself is off the frame loop.
+
+**Constraints**: no ɴsɪ API/node additions (R7); pure-Rust workspace
+preference weighs on the R3 MaterialX-dependency decision; profile v1
+excludes runtime-callback constructs (Non-Goals).
+
+## Constitution Check
+
+- Source-of-truth: `.specify/feature.json` remains
+  `specs/001-gpu-pixel-streaming` (001 implements first); this surface
+  activates when the pointer moves here.
+- Required artifacts: all eight present in this directory.
+- Evidence policy: `contracts/profile-conformance.md` includes
+  `Required Evidence Before Marking Complete`; all rows `Open`.
+- Scope: three `[NEEDS CLARIFY]` markers (closure list, MaterialX nodedefs
+  vs native, WGSL target) must be resolved via `/clarify` before
+  implementation.
+
+## Project Structure
+
+```text
+specs/002-shading-profile/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── checklists/
+│   └── requirements.md
+└── contracts/
+    └── profile-conformance.md
+
+crates/nsi-profile/           (new, this feature; name tentative)
+├── src/
+│   ├── lib.rs                registry, versioning, resolution
+│   ├── validate.rs           US3 validator
+│   ├── translate.rs          network → NetworkModule
+│   ├── emit/                 SPIR-V emitters
+│   └── nodes/                NodeDefs + ᴏsʟ references
+├── osl/                      ᴏsʟ reference sources
+└── tests/                    contract-derived tests + parity fixtures
+```
+
+## Execution Rules
+
+1. Resolve the three `[NEEDS CLARIFY]` markers before implementation.
+2. Work one user story or one contract row at a time.
+3. Add or update tests from the contract invariants before ticking rows.
+4. Mark rows `Covered` only after the listed evidence commands ran.
+
+## Artifact Checklist
+
+- [ ] Active feature pointer is updated (deliberately not -- 001 first).
+- [x] Required artifact set exists.
+- [x] Each contract file has `Required Evidence Before Marking Complete`.

--- a/specs/002-shading-profile/quickstart.md
+++ b/specs/002-shading-profile/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart: Shading Profile
+
+**Current status: spec only.** `crates/nsi-profile` does not exist yet; the
+commands below are the verification path once tasks in `tasks.md` land.
+Nothing here is evidence until it has actually been run.
+
+## Build And Test
+
+```bash
+# Registry, resolution, validator, layout tests (no renderer required).
+cargo test -p nsi-profile
+
+# MaterialX interchange rows.
+cargo test -p nsi-profile --features materialx
+
+# Parity harness (requires 3Delight installed and DELIGHT set).
+cargo test -p nsi-profile --features parity
+```
+
+Never use `--release` (repo rule, see `AGENTS.md`). Expected-image updates
+(`RUST_TEST_UPDATE=1`) require explicit human approval.
+
+## Manual QA Path
+
+1. Validate a fixture scene:
+
+   ```bash
+   cargo run -p nsi-profile --bin nsi-profile-validate -- \
+       tests/fixtures/conforming.nsi
+   ```
+
+   Confirm empty report, exit code 0; repeat with
+   `tests/fixtures/violating.nsi` and confirm the report names the shader
+   node handle, construct, and profile version.
+2. Render a parity fixture both ways and inspect the comparison output:
+
+   ```bash
+   cargo test -p nsi-profile --features parity parity_standard_surface -- --nocapture
+   ```
+
+3. For emission parity, run the light-rig fixture and confirm each light
+   pattern's illumination difference is within its declared threshold.
+
+Record 3Delight version, OS, and thresholds when citing this path as
+contract evidence.

--- a/specs/002-shading-profile/research.md
+++ b/specs/002-shading-profile/research.md
@@ -1,0 +1,62 @@
+# Research: Shading Profile
+
+Inherits decision D7 from `specs/001-gpu-pixel-streaming/research.md`
+(network translation over ᴏsʟ execution; rejected NVIDIA-only OptiX reuse,
+ᴏsʟ→SPIR-V backend, CPU-only shading).
+
+## D1: Dual-Implementation Nodes (ᴏsʟ Reference + GPU Codegen)
+
+**Decision.** Every profile node has two implementations of record: an ᴏsʟ
+reference (executed by offline renderers -- this is what 3Delight sees) and
+a GPU emitter. Parity between them is the product (US2), enforced by an
+image-comparison harness.
+
+**Why.** This is MaterialX's proven model (nodedefs with per-target
+implementations) and it keeps one ɴsɪ scene renderable on both paths with
+no scene-side branching.
+
+**Rejected.** GPU-only node definitions -- forfeits offline parity and the
+existing 3Delight validation path.
+
+## D2: Closures As The Integrator Boundary
+
+**Decision.** The profile vocabulary bottoms out in closures, mirroring
+ᴏsʟ's architecture: networks compute closure weights/parameters; the
+integrator owns sampling. `emission()` is a first-class profile closure
+because ɴsɪ has no light nodes -- lights are emissive geometry.
+
+**Rejected.** A monolithic "uber material" parameter struct as the only
+surface -- simpler to start but bakes one material model into the contract
+and cannot express ɴsɪ's emissive-geometry lighting idiomatically.
+
+## D3: MaterialX Alignment, Pending R3
+
+Aligning the node set with a MaterialX stdlib subset buys interchange (US5)
+and possibly its shadergen. Open question (R3 in `spec.md`): reuse
+MaterialX nodedefs/shadergen directly (C++ dependency, GLSL→SPIR-V
+toolchain) vs. ɴsɪ-native definitions in Rust with a mapping layer
+(cleaner workspace fit, more emitter work). Evidence to gather before
+deciding: whether MaterialX shadergen output is usable under Vulkan without
+per-node patching, and the dependency cost in this pure-Rust workspace.
+
+## D4: Deterministic Parameter Blocks
+
+Translated networks must yield stable, documented parameter-block layouts
+(R6) so engines can animate material parameters per frame without
+re-translation -- the same edit-with-attributes philosophy ɴsɪ applies to
+scene data, applied to materials. Re-translation happens only on topology
+edits (connect/disconnect), mirroring how `synchronize` distinguishes
+attribute edits from structural edits.
+
+## References
+
+- D7 decision record: `specs/001-gpu-pixel-streaming/research.md`.
+- ᴏsʟ GPU status (OptiX-only upstream backend):
+  <https://github.com/AcademySoftwareFoundation/OpenShadingLanguage>.
+- MaterialX shadergen: <https://materialx.org/>.
+- Isotropix Angie precedent (ᴏsʟ + MaterialX, hybrid CPU/GPU):
+  <https://www.fxguide.com/quicktakes/angie-hybrid-renderer-from-isotropix/>.
+- ɴsɪ lighting model (emissive geometry):
+  <https://nsi.readthedocs.io/en/latest/guidelines.html>.
+- Existing image-comparison test machinery: `AGENTS.md`
+  (`RUST_TEST_UPDATE=1`).

--- a/specs/002-shading-profile/spec.md
+++ b/specs/002-shading-profile/spec.md
@@ -1,0 +1,131 @@
+# Feature Spec: Shading Profile (Closure/Node Vocabulary)
+
+The fixed, versioned vocabulary of shader nodes and closures that a realtime
+ɴsɪ backend evaluates by *translating shader networks* to portable GPU code
+(SPIR-V), instead of executing arbitrary ᴏsʟ. Direction decided in
+`specs/001-gpu-pixel-streaming/research.md` D7. Closures stay the boundary
+between shading and the integrator, exactly as in ᴏsʟ; what the profile
+fixes is *which* nodes and closures exist per version.
+
+## User Stories
+
+### User Story 1: Versioned Closure Vocabulary (P1)
+
+As a realtime-backend author, I want a fixed, versioned set of closures
+with defined parameter semantics, so that my integrator can evaluate
+materials without an ᴏsʟ runtime.
+
+**Acceptance Criteria**
+
+- Given a profile version, when a backend declares support for it, then
+  every closure in that version has defined parameters, units, and
+  normalization documented in the profile.
+- Given a network using only version-N vocabulary, when validated against
+  version N, then validation passes; when it uses anything else, validation
+  fails naming the offending node/closure.
+
+### User Story 2: Offline/Realtime Parity (P1)
+
+As a look developer, I want every profile node to ship an ᴏsʟ reference
+implementation, so that the same ɴsɪ scene renders with matching material
+appearance offline (3Delight executing the ᴏsʟ references) and realtime
+(GPU code translated from the same network).
+
+**Acceptance Criteria**
+
+- Given a profile test scene, when rendered via the ᴏsʟ references and via
+  the GPU translation, then per-material outputs match within the declared
+  tolerance (image-comparison harness, not pixel-exact).
+- Given a parameter change on a profile node, when re-rendered both ways,
+  then both outputs change consistently.
+
+### User Story 3: Loud Profile Validation (P2)
+
+As a pipeline TD, I want a validation tool that reports whether a scene's
+shader networks are inside a profile version, so that unsupported ᴏsʟ fails
+loudly before a realtime render, not silently mid-frame.
+
+**Acceptance Criteria**
+
+- Given a scene with an out-of-profile shader, when validated, then the
+  report names the shader node handle, the construct, and the profile
+  version consulted.
+- Given a conforming scene, when validated, then the report is empty and
+  exits zero.
+
+### User Story 4: Emission Parity (P2)
+
+As a scene author, I want lights -- which in ɴsɪ are geometry with
+`emission()` closures -- fully covered by the profile, so that area, spot,
+point, directional, and HDR environment lighting work identically offline
+and realtime.
+
+**Acceptance Criteria**
+
+- Given each documented ɴsɪ light construction pattern, when rendered both
+  ways, then illumination matches within tolerance.
+
+### User Story 5: MaterialX Interchange (P3)
+
+As a DCC integrator, I want profile networks to map to/from MaterialX
+documents, so that existing MaterialX assets flow into ɴsɪ scenes without
+re-authoring.
+
+**Acceptance Criteria**
+
+- Given a MaterialX document using the mapped node set, when imported, then
+  the resulting ɴsɪ shader network validates against the profile and
+  renders equivalently.
+
+## Non-Goals
+
+- Executing arbitrary ᴏsʟ on the GPU (rejected as option C in D7).
+- A new authoring language -- authoring is node networks (and MaterialX
+  interchange); hand-written ᴏsʟ remains first-class for offline renderers
+  through the same scene.
+- Pixel-exact parity with 3Delight -- parity is material appearance within
+  declared tolerance; sampling/integration differences are out of scope.
+- `trace()`, `getattribute()` against arbitrary scene state, string
+  operations, and dictionary lookups -- excluded from profile v1 (these are
+  the runtime-callback constructs that make full ᴏsʟ-on-Vulkan hard).
+- The realtime backend/integrator itself (coverage-order item 5).
+
+## Requirements
+
+- R1: The profile is versioned; networks declare (or are validated against)
+  a profile version. Version negotiation failures are typed and loud.
+- R2: The closure set is fixed per version. [NEEDS CLARIFY: exact v1
+  closure list -- proposed baseline: `diffuse` (Oren-Nayar), `microfacet`
+  GGX (reflect/refract), conductor/dielectric parameterizations, `sheen`,
+  `emission`, `transparent`, `holdout`; decide whether subsurface is v1 or
+  v2.]
+- R3: The node set is derived from a MaterialX standard-library subset,
+  with ɴsɪ-native naming. [NEEDS CLARIFY: are profile nodes defined as
+  MaterialX nodedefs (reusing its shadergen infrastructure) or ɴsɪ-native
+  definitions with a MaterialX mapping layer?]
+- R4: Translation target is SPIR-V. [NEEDS CLARIFY: is a WGSL target
+  needed for `wgpu`-based backends, or is SPIR-V passthrough sufficient?]
+- R5: Every profile node ships an ᴏsʟ reference implementation; the
+  reference set is what offline renderers execute (US2 parity).
+- R6: Each translated network yields a deterministic parameter-block layout
+  (a wire format -- documented and versioned like `stream.*`).
+- R7: Profile nodes are addressed from ɴsɪ `shader` nodes via a
+  distinguished `shaderfilename` scheme (working sketch:
+  `"nsi-profile:<node>@<version>"`), so a conforming scene needs no new
+  node types (mirrors R1 of feature 001).
+- R8: A standalone validator implements US3 and is usable in CI.
+
+## Risks
+
+- MaterialX shadergen has no WGSL target and its Vulkan story is
+  GLSL-then-SPIR-V; if R3 lands on MaterialX nodedefs, the SPIR-V path
+  inherits that toolchain. Mitigation: R4 clarification; keep codegen
+  behind a trait so glslang-based and native emitters are swappable.
+- Closure semantics drift between the ᴏsʟ references (as 3Delight evaluates
+  them) and GPU code. Mitigation: US2's image-comparison harness is the
+  contract, run in CI against fixture scenes; the repo already has
+  expected-image test machinery (`RUST_TEST_UPDATE`).
+- Scope creep toward full ᴏsʟ. Mitigation: the excluded-constructs list in
+  Non-Goals is normative; additions require a profile version bump.
+- Tolerance definition disputes. Mitigation: per-fixture thresholds
+  declared in the contract, not ad hoc.

--- a/specs/002-shading-profile/tasks.md
+++ b/specs/002-shading-profile/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Shading Profile
+
+Dependency-ordered; implementation starts after feature 001 (the active
+pointer stays on 001 until then). Tasks S1--S2 are blocked on `/clarify`
+resolving the three `[NEEDS CLARIFY]` markers in `spec.md`.
+
+## Setup
+
+- [ ] S1: Resolve `[NEEDS CLARIFY]` markers (v1 closure list, MaterialX
+  nodedefs vs ɴsɪ-native, WGSL target) and record answers in `spec.md`.
+  Evidence: spec with markers removed.
+- [ ] S2: Freeze profile v1: ClosureDef and NodeDef tables in
+  `data-model.md`. Evidence: `/analyze` shows no drift.
+- [ ] S3: Scaffold `crates/nsi-profile` (registry, versioning, typed
+  errors). Evidence: `cargo build -p nsi-profile`.
+
+## User Story 1 -- Versioned Closure Vocabulary (P1)
+
+- [ ] S4: `nsi-profile:<node>@<version>` resolution + version negotiation.
+  Evidence: `resolve_scheme`.
+- [ ] S5: Registry completeness check (every NodeDef has both targets).
+  Evidence: `nodedef_completeness`.
+
+## User Story 3 -- Loud Validation (P2, pulled early: gates everything)
+
+- [ ] S6: Validator + CI wiring, fixture scenes (conforming + violating).
+  Evidence: `validator_violations`, `validator_clean`.
+
+## User Story 2 -- Offline/Realtime Parity (P1)
+
+- [ ] S7: ᴏsʟ reference set for v1 nodes. Evidence: fixture scenes render
+  via 3Delight (`DELIGHT` set).
+- [ ] S8: SPIR-V emitters for v1 nodes; ParameterBlock layout golden
+  files. Evidence: `parameter_block_layout`.
+- [ ] S9: Parity harness (image comparison, per-fixture thresholds) in CI.
+  Evidence: parity rows of the contract.
+- [ ] S10: Edit classification (parameter update vs re-translate).
+  Evidence: `edit_classification`.
+
+## User Story 4 -- Emission Parity (P2)
+
+- [ ] S11: Light-rig fixtures (area, spot, point, directional, HDR
+  environment) through the parity harness. Evidence: emission parity row.
+
+## User Story 5 -- MaterialX Interchange (P3)
+
+- [ ] S12: `materialx` feature: import mapping for the documented subset.
+  Evidence: `mtlx_roundtrip`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,37 @@
+# Specs
+
+Feature specs live in this directory. The active feature directory is stored
+in `.specify/feature.json`.
+
+## Coverage Order
+
+Surfaces on the path from "interactive" (the API's design target) to
+"realtime" (frame-budget) use, in intended coverage order:
+
+1. Pixel streaming/output contract -- how rendered pixels reach a client with
+   GPU residency (`001-gpu-pixel-streaming`).
+2. Input-side data residency -- zero-copy/GPU-handle geometry and attribute
+   handoff via `Reference`-style arguments.
+3. Frame pacing and temporal semantics -- publication deadlines, edit-class
+   fast paths across `synchronize`.
+4. Realtime backend -- an `Nsi`-trait renderer implementation consuming 1--3.
+
+## Definition Of Covered
+
+A surface is covered only when all of these are present:
+
+- A feature spec exists in `specs/<feature>/spec.md`.
+- Contracts exist in `specs/<feature>/contracts/`.
+- Implementation tasks exist in `specs/<feature>/tasks.md`.
+- Every contract matrix row is `Covered`, `Partial`, or `Open`.
+- Each `Covered` row cites source evidence and either executable test
+  evidence or explicit manual QA evidence.
+- Each contract file contains a `Required Evidence Before Marking Complete`
+  section.
+
+Docs, checkboxes, and TODOs are not evidence by themselves.
+
+## Active Spec
+
+Current active feature:
+`specs/001-gpu-pixel-streaming/spec.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,13 @@ Surfaces on the path from "interactive" (the API's design target) to
    handoff via `Reference`-style arguments.
 3. Frame pacing and temporal semantics -- publication deadlines, edit-class
    fast paths across `synchronize`.
-4. Realtime backend -- an `Nsi`-trait renderer implementation consuming 1--3.
+4. Shading profile -- the fixed closure/node vocabulary for network
+   translation to SPIR-V (`002-shading-profile`; direction decided in
+   `001-gpu-pixel-streaming/research.md` D7; arbitrary ᴏsʟ stays offline).
+5. Realtime backend -- an `Nsi`-trait renderer implementation consuming
+   1--4.
+
+Directory numbers reflect creation order, not coverage order.
 
 ## Definition Of Covered
 


### PR DESCRIPTION
Adds virtualritz/blueprints as the .blueprints submodule and seeds the opt-in spec-driven workflow: .specify pointer and constitution, specs/README.md, workflow slash commands, and the AGENTS.md block.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YKn1dhbbXBVEEAWEBbjxqy